### PR TITLE
Remove extra i from method name

### DIFF
--- a/src/test/scala/samples/scalatest.scala
+++ b/src/test/scala/samples/scalatest.scala
@@ -31,7 +31,7 @@ import org.junit.Test
 
 class StackSuite extends Assertions {
 
-  @Test def stackShouldPopValuesIinLastInFirstOutOrder() {
+  @Test def stackShouldPopValuesInLastInFirstOutOrder() {
     val stack = new Stack[Int]
     stack.push(1)
     stack.push(2)


### PR DESCRIPTION
There is an extra letter 'i' in "stackShouldPopValuesIinLastInFirstOutOrder", "ValuesIinLastIn" => "ValuesInLastIn"